### PR TITLE
Fixing Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-- 2.3.1
-- 2.2.5
+- 2.7.1
+- 2.6.6
 env:
   matrix:
     - FOO=BAR

--- a/squares.gemspec
+++ b/squares.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-given"


### PR DESCRIPTION
Removes bundler as a dev dependency, and updates versions of Ruby.